### PR TITLE
[rugk.dedyn.io] New ruleset

### DIFF
--- a/src/chrome/content/rules/Rugk.dedyn.io.xml
+++ b/src/chrome/content/rules/Rugk.dedyn.io.xml
@@ -1,0 +1,11 @@
+<!--
+
+-->
+<ruleset name="rugk.dedyn.io">
+    <target host="rugk.dedyn.io" />
+
+    <securecookie host="^rugk\.dedyn\.io$" name=".+" />
+
+    <rule from="^http:"
+            to="https:" />
+</ruleset>


### PR DESCRIPTION
`.dedyn.io` is a [public suffix](https://github.com/publicsuffix/list/blob/2226f9cc92213d0d68a74ecb535b15b3af00388a/public_suffix_list.dat#L10812-L10814) as it is a dynamic DNS service, so this is the reason why there can't be a `dedyn.io` ruleset.
